### PR TITLE
Fix broken (Forbidden) source url links

### DIFF
--- a/cross_toolchain/recipes/x86_64/binutils-pass1.sh
+++ b/cross_toolchain/recipes/x86_64/binutils-pass1.sh
@@ -12,7 +12,7 @@ src_file=$BASH_SOURCE
 
 # package details
 MD5_SUM="a075178a9646551379bfb64040487715"
-DOWNLOAD_URLS[$MD5_SUM]="https://sourceware.org/pub/binutils/releases/binutils-2.42.tar.xz"
+DOWNLOAD_URLS[$MD5_SUM]="https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
 SRC_COMPRESSED_FILE=$(basename ${DOWNLOAD_URLS[$MD5_SUM]})
 SRC_FOLDER=${SRC_COMPRESSED_FILE%.*.*}
 

--- a/cross_toolchain/recipes/x86_64/binutils-pass2.sh
+++ b/cross_toolchain/recipes/x86_64/binutils-pass2.sh
@@ -13,7 +13,7 @@ src_file=$BASH_SOURCE
 
 # package details
 MD5_SUM="a075178a9646551379bfb64040487715"
-DOWNLOAD_URLS[$MD5_SUM]="https://sourceware.org/pub/binutils/releases/binutils-2.42.tar.xz"
+DOWNLOAD_URLS[$MD5_SUM]="https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
 SRC_COMPRESSED_FILE=$(basename ${DOWNLOAD_URLS[$MD5_SUM]})
 SRC_FOLDER=${SRC_COMPRESSED_FILE%.*.*}
 

--- a/install_scripts/packages/recipes/x86_64/basic/Binutils.sh
+++ b/install_scripts/packages/recipes/x86_64/basic/Binutils.sh
@@ -12,7 +12,7 @@ declare -a RUNTIME_DEPS=()
 
 # package details
 MD5_SUM="a075178a9646551379bfb64040487715"
-DOWNLOAD_URLS[$MD5_SUM]="https://sourceware.org/pub/binutils/releases/binutils-2.42.tar.xz"
+DOWNLOAD_URLS[$MD5_SUM]="https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
 SRC_COMPRESSED_FILE=$(basename ${DOWNLOAD_URLS[$MD5_SUM]})
 SRC_FOLDER=${SRC_COMPRESSED_FILE%.*.*}
 

--- a/install_scripts/packages/recipes/x86_64/basic/Bzip2.sh
+++ b/install_scripts/packages/recipes/x86_64/basic/Bzip2.sh
@@ -12,7 +12,7 @@ declare -a RUNTIME_DEPS=()
 
 # package details
 MD5_SUM="67e051268d0c475ea773822f7500d0e5"
-DOWNLOAD_URLS[$MD5_SUM]="https://www.sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+DOWNLOAD_URLS[$MD5_SUM]="https://sources.openwrt.org/bzip2-1.0.8.tar.gz"
 DOWNLOAD_URLS["6a5ac7e89b791aae556de0f745916f7f"]="https://www.linuxfromscratch.org/patches/lfs/12.1/bzip2-1.0.8-install_docs-1.patch"
 SRC_COMPRESSED_FILE=$(basename ${DOWNLOAD_URLS[$MD5_SUM]})
 SRC_FOLDER=${SRC_COMPRESSED_FILE%.*.*}

--- a/install_scripts/packages/recipes/x86_64/basic/Elfutils.sh
+++ b/install_scripts/packages/recipes/x86_64/basic/Elfutils.sh
@@ -12,7 +12,7 @@ declare -a RUNTIME_DEPS=()
 
 # package details
 MD5_SUM="79ad698e61a052bea79e77df6a08bc4b"
-DOWNLOAD_URLS[$MD5_SUM]="https://sourceware.org/ftp/elfutils/0.190/elfutils-0.190.tar.bz2"
+DOWNLOAD_URLS[$MD5_SUM]="https://ftp.kr.freebsd.org/pub/cygwin.com/elfutils/0.190/elfutils-0.190.tar.bz2"
 SRC_COMPRESSED_FILE=$(basename ${DOWNLOAD_URLS[$MD5_SUM]})
 SRC_FOLDER=${SRC_COMPRESSED_FILE%.*.*}
 


### PR DESCRIPTION
Due to the unavailability of the sourceware.org repository (Forbidden), I changed the download urls for the binutils, bzip2 and elfutils packages. There was no change in the md5 check sums.